### PR TITLE
ユーザー名のUnicode対応と役職フィルターの改善

### DIFF
--- a/app/(authenticated)/members/manage/_components/manage-members-client.tsx
+++ b/app/(authenticated)/members/manage/_components/manage-members-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { ArrowUpDown, ArrowUp, ArrowDown, Search, X } from "lucide-react";
+import { ArrowUpDown, ArrowUp, ArrowDown, Search, X, ChevronDown } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -12,6 +12,12 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -112,7 +118,8 @@ export function ManageMembersClient({
   const [filterName, setFilterName] = useState("");
   const [filterStudentNumber, setFilterStudentNumber] = useState("");
   const [filterGrade, setFilterGrade] = useState<string>("all");
-  const [filterRole, setFilterRole] = useState<string>("all");
+  const [filterRoles, setFilterRoles] = useState<string[]>([]);
+  const [showActiveOnly, setShowActiveOnly] = useState(false);
 
   const handleRetire = async () => {
     if (!retireTarget) return;
@@ -179,6 +186,12 @@ export function ManageMembersClient({
     return Array.from(set).sort((a, b) => a - b);
   }, [members]);
 
+  const toggleRole = (role: string) => {
+    setFilterRoles((prev) =>
+      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role],
+    );
+  };
+
   const toggleSort = (key: SortKey) => {
     setSort((prev) => {
       if (prev?.key === key) {
@@ -190,13 +203,18 @@ export function ManageMembersClient({
   };
 
   const hasActiveFilter =
-    filterName || filterStudentNumber || filterGrade !== "all" || filterRole !== "all";
+    !!filterName ||
+    !!filterStudentNumber ||
+    filterGrade !== "all" ||
+    filterRoles.length > 0 ||
+    showActiveOnly;
 
   const clearFilters = () => {
     setFilterName("");
     setFilterStudentNumber("");
     setFilterGrade("all");
-    setFilterRole("all");
+    setFilterRoles([]);
+    setShowActiveOnly(false);
   };
 
   const filtered = useMemo(() => {
@@ -209,11 +227,13 @@ export function ManageMembersClient({
         return false;
       if (filterGrade !== "all" && m.grade !== Number(filterGrade))
         return false;
-      if (filterRole !== "all" && !m.role_names.includes(filterRole))
-        return false;
+      if (filterRoles.length > 0) {
+        if (!filterRoles.some((r) => m.role_names.includes(r))) return false;
+      }
+      if (showActiveOnly && m.grade === 0) return false;
       return true;
     });
-  }, [members, filterName, filterStudentNumber, filterGrade, filterRole]);
+  }, [members, filterName, filterStudentNumber, filterGrade, filterRoles, showActiveOnly]);
 
   const sorted = useMemo(() => {
     if (!sort) return filtered;
@@ -286,19 +306,51 @@ export function ManageMembersClient({
             <label className="text-xs font-medium text-muted-foreground">
               役職
             </label>
-            <Select value={filterRole} onValueChange={setFilterRole}>
-              <SelectTrigger className="h-9 w-32 text-sm">
-                <SelectValue placeholder="全役職" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">全役職</SelectItem>
-                {allRoles.map((r) => (
-                  <SelectItem key={r.id} value={r.name}>
-                    {r.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-9 w-36 justify-between text-sm font-normal"
+                >
+                  <span className="truncate">
+                    {filterRoles.length === 0
+                      ? "全役職"
+                      : `${filterRoles.length}件選択中`}
+                  </span>
+                  <ChevronDown className="ml-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-48 p-2" align="start">
+                <div className="space-y-1">
+                  {allRoles.map((r) => (
+                    <label
+                      key={r.id}
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+                    >
+                      <Checkbox
+                        checked={filterRoles.includes(r.name)}
+                        onCheckedChange={() => toggleRole(r.name)}
+                      />
+                      {r.name}
+                    </label>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <div className="flex items-center gap-2 self-end pb-1">
+            <Checkbox
+              id="manage-active-only"
+              checked={showActiveOnly}
+              onCheckedChange={(v) => setShowActiveOnly(!!v)}
+            />
+            <label
+              htmlFor="manage-active-only"
+              className="cursor-pointer text-sm text-muted-foreground"
+            >
+              現役部員のみ
+            </label>
           </div>
           {hasActiveFilter && (
             <Button

--- a/app/(authenticated)/members/manage/actions.ts
+++ b/app/(authenticated)/members/manage/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createAdminClient } from "@/utils/supabase/server";
+
 import {
   createUserSchema,
   deriveEmail,
@@ -20,6 +21,17 @@ import {
   memberIdSchema,
   validateInput,
 } from "@/lib/validations";
+
+// GoTrue (Supabase Auth) may reject supplementary Unicode characters (U+10000+)
+// in user_metadata. Preserve the original name only in the profiles table.
+function sanitizeForGoTrue(name: string): string {
+  return [...name]
+    .map((ch) => {
+      const cp = ch.codePointAt(0)!;
+      return cp > 0xffff ? `[U+${cp.toString(16).toUpperCase()}]` : ch;
+    })
+    .join("");
+}
 
 // --- 部員追加 ---
 export async function addMember(raw: {
@@ -56,7 +68,7 @@ export async function addMember(raw: {
       password,
       email_confirm: true,
       user_metadata: {
-        name: input.name,
+        name: sanitizeForGoTrue(input.name),
         student_number: input.student_number,
         grade: input.grade,
       },
@@ -151,7 +163,7 @@ export async function updateMember(
   // 2) auth user metadata update - requires admin client for auth.admin.*
   const { error: authErr } = await admin.auth.admin.updateUserById(userId, {
     user_metadata: {
-      name: data.name,
+      name: sanitizeForGoTrue(data.name),
       student_number: data.student_number,
       grade: data.grade,
     },

--- a/components/members-table.tsx
+++ b/components/members-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { ArrowUpDown, ArrowUp, ArrowDown, Search, X } from "lucide-react";
+import { ArrowUpDown, ArrowUp, ArrowDown, Search, X, ChevronDown } from "lucide-react";
 import {
   Table,
   TableBody,
@@ -13,6 +13,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -75,7 +81,8 @@ export function MembersTable({ members }: { members: MemberRow[] }) {
   const [filterName, setFilterName] = useState("");
   const [filterStudentNumber, setFilterStudentNumber] = useState("");
   const [filterGrade, setFilterGrade] = useState<string>("all");
-  const [filterRole, setFilterRole] = useState<string>("all");
+  const [filterRoles, setFilterRoles] = useState<string[]>([]);
+  const [showActiveOnly, setShowActiveOnly] = useState(false);
 
   const grades = useMemo(() => {
     const set = new Set(
@@ -92,6 +99,12 @@ export function MembersTable({ members }: { members: MemberRow[] }) {
     return Array.from(set).sort((a, b) => a.localeCompare(b, "ja"));
   }, [members]);
 
+  const toggleRole = (role: string) => {
+    setFilterRoles((prev) =>
+      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role],
+    );
+  };
+
   const toggleSort = (key: SortKey) => {
     setSort((prev) => {
       if (prev?.key === key) {
@@ -103,13 +116,18 @@ export function MembersTable({ members }: { members: MemberRow[] }) {
   };
 
   const hasActiveFilter =
-    filterName || filterStudentNumber || filterGrade !== "all" || filterRole !== "all";
+    !!filterName ||
+    !!filterStudentNumber ||
+    filterGrade !== "all" ||
+    filterRoles.length > 0 ||
+    showActiveOnly;
 
   const clearFilters = () => {
     setFilterName("");
     setFilterStudentNumber("");
     setFilterGrade("all");
-    setFilterRole("all");
+    setFilterRoles([]);
+    setShowActiveOnly(false);
   };
 
   const filtered = useMemo(() => {
@@ -122,11 +140,14 @@ export function MembersTable({ members }: { members: MemberRow[] }) {
         return false;
       if (filterGrade !== "all" && m.grade !== Number(filterGrade))
         return false;
-      if (filterRole !== "all" && !m.roles.split("、").includes(filterRole))
-        return false;
+      if (filterRoles.length > 0) {
+        const memberRoles = m.roles.split("、").map((r) => r.trim());
+        if (!filterRoles.some((r) => memberRoles.includes(r))) return false;
+      }
+      if (showActiveOnly && m.grade === 0) return false;
       return true;
     });
-  }, [members, filterName, filterStudentNumber, filterGrade, filterRole]);
+  }, [members, filterName, filterStudentNumber, filterGrade, filterRoles, showActiveOnly]);
 
   const sorted = useMemo(() => {
     if (!sort) return filtered;
@@ -198,19 +219,51 @@ export function MembersTable({ members }: { members: MemberRow[] }) {
           <label className="text-xs font-medium text-muted-foreground">
             役職
           </label>
-          <Select value={filterRole} onValueChange={setFilterRole}>
-            <SelectTrigger className="h-9 w-32 text-sm">
-              <SelectValue placeholder="全役職" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">全役職</SelectItem>
-              {roleOptions.map((r) => (
-                <SelectItem key={r} value={r}>
-                  {r}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-9 w-36 justify-between text-sm font-normal"
+              >
+                <span className="truncate">
+                  {filterRoles.length === 0
+                    ? "全役職"
+                    : `${filterRoles.length}件選択中`}
+                </span>
+                <ChevronDown className="ml-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-48 p-2" align="start">
+              <div className="space-y-1">
+                {roleOptions.map((r) => (
+                  <label
+                    key={r}
+                    className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+                  >
+                    <Checkbox
+                      checked={filterRoles.includes(r)}
+                      onCheckedChange={() => toggleRole(r)}
+                    />
+                    {r}
+                  </label>
+                ))}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div className="flex items-center gap-2 self-end pb-1">
+          <Checkbox
+            id="active-only"
+            checked={showActiveOnly}
+            onCheckedChange={(v) => setShowActiveOnly(!!v)}
+          />
+          <label
+            htmlFor="active-only"
+            className="cursor-pointer text-sm text-muted-foreground"
+          >
+            現役部員のみ
+          </label>
         </div>
         {hasActiveFilter && (
           <Button

--- a/lib/account.ts
+++ b/lib/account.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const createUserSchema = z.object({
   name: z.string().min(1, "氏名は必須です"),
-  student_number: z.string().regex(/^\d{7}$/g, "学籍番号は7桁の数字です"),
+  student_number: z.string().regex(/^\d{7}$/, "学籍番号は7桁の数字です"),
   grade: z
     .number({ invalid_type_error: "学年は数値で入力してください" })
     .int()

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -6,7 +6,7 @@ export const uuidSchema = z.string().uuid("Invalid UUID format");
 
 export const studentNumberSchema = z
   .string()
-  .regex(/^\d{7}$/g, "Student number must be 7 digits");
+  .regex(/^\d{7}$/, "Student number must be 7 digits");
 
 // --- Server action input schemas ---
 


### PR DESCRIPTION
ユーザー名のUnicode文字をGoTrueに適合させるための関数を追加し、メンバーの追加および更新時に適用。役職フィルターをチェックボックス形式に変更し、現役部員のみを表示するオプションを追加。フィルタリングロジックを更新。