### PR TITLE
部全体会計・財布別記録機能の追加

### DIFF
--- a/app/(authenticated)/ledger/actions.ts
+++ b/app/(authenticated)/ledger/actions.ts
@@ -15,10 +15,13 @@
 import { getAccountingUserIdSync } from "@/lib/system-config";
 import {
   fetchLedgerTransactionsSchema,
+  createTransferSchema,
   validateInput,
 } from "@/lib/validations";
 import { resolveAuthWithRoles } from "@/lib/auth/context";
 import { ROLE_NAMES_JA } from "@/lib/roles/constants";
+import { revalidatePath } from "next/cache";
+import { canViewClubLedger } from "@/lib/auth/permissions";
 
 import {
   TransactionRow,
@@ -51,22 +54,26 @@ export async function fetchLedgerTransactions(params: {
 
   const requestedGroupId = params.accountingGroupId;
 
-  // general タイプのグループは全ユーザーに公開
-  let isGeneralGroup = false;
-  if (!isFullAccess) {
-    const { data: groupInfo } = await auth.supabase
-      .from("accounting_groups")
-      .select("type")
-      .eq("id", requestedGroupId)
-      .maybeSingle();
-    isGeneralGroup = groupInfo?.type === "general";
+  // Check group type for access control
+  const { data: groupInfo } = await auth.supabase
+    .from("accounting_groups")
+    .select("type")
+    .eq("id", requestedGroupId)
+    .maybeSingle();
+
+  const isClubGroup = groupInfo?.type === "club";
+  const isGeneralGroup = groupInfo?.type === "general";
+
+  // Club-wide group: only accounting/admin can view
+  if (isClubGroup && !canViewClubLedger(access)) {
+    return { error: "アクセス権限がありません" as const };
   }
 
   const belongsToRequested = access.roles.some(
     (r) => r.accountingGroupId && r.accountingGroupId === requestedGroupId,
   );
 
-  if (!isFullAccess && !isGeneralGroup && !belongsToRequested) {
+  if (!isClubGroup && !isFullAccess && !isGeneralGroup && !belongsToRequested) {
     return { error: "アクセス権限がありません" as const };
   }
 
@@ -74,7 +81,7 @@ export async function fetchLedgerTransactions(params: {
   let txQuery = auth.supabase
     .from("transactions")
     .select(
-      "id, date, amount, description, accounting_group_id, approval_status, receipt_url, created_by, approved_by, rejected_reason, remarks, subsidy_item_id",
+      "id, date, amount, description, accounting_group_id, approval_status, receipt_url, created_by, approved_by, rejected_reason, remarks, subsidy_item_id, financial_account_id, transaction_kind, transfer_id",
     )
     .eq("accounting_group_id", requestedGroupId)
     .order("date", { ascending: false });
@@ -115,6 +122,16 @@ export async function fetchLedgerTransactions(params: {
     return { error: "データの取得に失敗しました" as const };
   }
 
+  // Fetch financial account names for display
+  const { data: financialAccounts } = await auth.supabase
+    .from("financial_accounts")
+    .select("id, name")
+    .order("display_order");
+  const faNameMap: Record<string, string> = {};
+  for (const fa of financialAccounts || []) {
+    faNameMap[fa.id] = fa.name;
+  }
+
   const txRows: TransactionRow[] = (txResult.data || []).map((row) => ({
     id: row.id,
     date: row.date,
@@ -128,6 +145,10 @@ export async function fetchLedgerTransactions(params: {
     rejected_reason: row.rejected_reason,
     remarks: row.remarks,
     subsidy_item_id: row.subsidy_item_id,
+    financial_account_id: row.financial_account_id,
+    financial_account_name: faNameMap[row.financial_account_id] ?? null,
+    transaction_kind: row.transaction_kind,
+    transfer_id: row.transfer_id,
   }));
   const subsidyData = subsidyResult.data ?? [];
 
@@ -187,4 +208,78 @@ export async function fetchLedgerTransactions(params: {
   }));
 
   return { data: enriched, budgetAmount, carryoverAmount };
+}
+
+/**
+ * Fetch active financial accounts for form selectors.
+ */
+export async function fetchFinancialAccounts() {
+  const authResult = await resolveAuthWithRoles();
+  if (!authResult.ok) return { error: authResult.error };
+  const auth = authResult.context;
+
+  const { data, error } = await auth.supabase
+    .from("financial_accounts")
+    .select("id, name, type, is_active, display_order")
+    .eq("is_active", true)
+    .order("display_order");
+
+  if (error) {
+    console.error("[fetchFinancialAccounts] Error:", error);
+    return { error: "財布データの取得に失敗しました" as const };
+  }
+
+  return { data: data || [] };
+}
+
+/**
+ * Create a fund transfer (資金移動) between two financial accounts.
+ * Atomically inserts 2 transaction rows via the create_transfer RPC.
+ * Only accounting staff and admins can create transfers.
+ */
+export async function createTransfer(params: {
+  date: string;
+  amount: number;
+  fromAccountId: string;
+  toAccountId: string;
+  description: string;
+  receiptUrl?: string | null;
+  remarks?: string | null;
+}) {
+  const validation = validateInput(createTransferSchema, params);
+  if (!validation.success) {
+    return { error: validation.error };
+  }
+
+  const authResult = await resolveAuthWithRoles();
+  if (!authResult.ok) return { error: authResult.error };
+  const auth = authResult.context;
+  const access = authResult.access;
+
+  // Only accounting/admin can create transfers
+  if (!access.isAdmin && !access.hasAccountingRole) {
+    return { error: "資金移動の作成には会計担当または管理者権限が必要です" };
+  }
+
+  const { data: transferId, error: rpcError } = await auth.supabase.rpc(
+    "create_transfer",
+    {
+      p_date: params.date,
+      p_amount: params.amount,
+      p_from_account_id: params.fromAccountId,
+      p_to_account_id: params.toAccountId,
+      p_description: params.description,
+      p_receipt_url: params.receiptUrl ?? null,
+      p_remarks: params.remarks ?? null,
+      p_created_by: auth.profileId,
+    },
+  );
+
+  if (rpcError) {
+    console.error("[createTransfer] RPC error:", rpcError);
+    return { error: "資金移動の作成に失敗しました" };
+  }
+
+  revalidatePath("/ledger");
+  return { success: true, transferId };
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -207,20 +207,38 @@ export async function createTransaction(
       ? -Math.abs(parsedValues.amount)
       : Math.abs(parsedValues.amount);
 
-  // 将来拡張(部全体会計): insertData に financial_account_id, transaction_kind を追加。
-  // transaction_kind = "transfer" の場合は同一 transfer_id で2行を同時 insert する。
+  // Determine transaction_kind from type (income/expense)
+  const transactionKind = parsedValues.type === "expense" ? "expense" : "income";
+
+  // Check if the accounting group is club-wide (type=club)
+  // If so, verify the user has accounting/admin permission
+  const { data: groupInfo } = await auth.supabase
+    .from("accounting_groups")
+    .select("type")
+    .eq("id", parsedValues.accounting_group_id)
+    .maybeSingle();
+
+  if (groupInfo?.type === "club") {
+    const access = authResult.access;
+    if (!access.isAdmin && !access.hasAccountingRole) {
+      return { error: "部全体取引の作成には会計担当または管理者権限が必要です" };
+    }
+  }
+
   const insertData = {
     id: recordId,
     date: formatDateForDatabase(parsedValues.date),
     amount: finalAmount,
     accounting_group_id: parsedValues.accounting_group_id,
+    financial_account_id: parsedValues.financial_account_id,
+    transaction_kind: transactionKind,
     description: parsedValues.description,
     created_by: auth.profileId,
     fiscal_year_id: fy?.year ?? null,
     receipt_url: parsedValues.receipt_url ?? null,
     remarks: parsedValues.remarks ?? null,
-    // 全取引を pending で開始し、leader/admin の承認を経て approved に遷移する。
-    // 管理者でも初回は pending — 不正防止のため自己承認を禁止しているため。
+    // All transactions start as pending; leader/admin approval required.
+    // Even admins start as pending to prevent self-approval.
     approval_status: "pending",
   };
 
@@ -415,6 +433,8 @@ export async function updateTransaction(
     fiscal_year_id: fy?.year ?? null,
     date: formatDateForDatabase(values.date),
     accounting_group_id: values.accounting_group_id,
+    financial_account_id: values.financial_account_id,
+    transaction_kind: effectiveType === "expense" ? "expense" : "income",
   };
 
   if (values.receipt_url !== undefined) {

--- a/components/ledger-view.tsx
+++ b/components/ledger-view.tsx
@@ -16,15 +16,26 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { fetchLedgerTransactions } from "@/app/(authenticated)/ledger/actions";
+import {
+  fetchLedgerTransactions,
+  fetchFinancialAccounts,
+} from "@/app/(authenticated)/ledger/actions";
 import { ROLE_TYPES } from "@/lib/roles/constants";
 import { createClient } from "@/utils/supabase/client";
 import { FiscalYearSelector } from "@/components/fiscal-year-selector";
-import { calculateLedgerTotals } from "@/lib/ledger";
-import type { LedgerTransaction, LedgerInitialData } from "@/lib/ledger";
+import {
+  calculateLedgerTotals,
+  calculateClubLedgerSummary,
+} from "@/lib/ledger";
+import type {
+  LedgerTransaction,
+  LedgerInitialData,
+  FinancialAccountInfo,
+} from "@/lib/ledger";
 
 import {
   LedgerSummary,
+  ClubLedgerSummary,
   LedgerFilterBar,
   LedgerDesktopTable,
   LedgerMobileCards,
@@ -101,8 +112,19 @@ export default function LedgerView({
   // --- フィルタ state ---
   const [filterText, setFilterText] = useState("");
   const [filterStatus, setFilterStatus] = useState<string>("all");
+  const [filterAccountId, setFilterAccountId] = useState<string>("all");
+  const [filterKind, setFilterKind] = useState<string>("all");
+
+  // --- Financial accounts ---
+  const [financialAccounts, setFinancialAccounts] = useState<
+    FinancialAccountInfo[]
+  >([]);
 
   const isAdminOrAccounting = isAccountingUser || isGlobalAdmin;
+
+  // Detect if selected group is 部全体 (club-wide) by checking team name
+  const selectedTeam = teams.find((t) => t.id === selectedGroup);
+  const isClubWideGroup = selectedTeam?.name === "部全体";
 
   const userRoleStr = isGlobalAdmin
     ? ROLE_TYPES.ADMIN
@@ -127,6 +149,16 @@ export default function LedgerView({
     },
     [sortKey, sortDir],
   );
+
+  // --- Financial accounts effect (load once) ---
+  useEffect(() => {
+    void (async () => {
+      const res = await fetchFinancialAccounts();
+      if (!("error" in res) && res.data) {
+        setFinancialAccounts(res.data.map((fa) => ({ id: fa.id, name: fa.name })));
+      }
+    })();
+  }, []);
 
   // --- グループ / 年度変更 + Realtime + ledger-refresh を統合した effect ---
   // fetchData を effect 内のローカル関数として定義し、
@@ -210,6 +242,12 @@ export default function LedgerView({
     [rows, budgetAmount, carryoverAmount],
   );
 
+  // --- Club-wide summary (only when club group is selected) ---
+  const clubSummary = useMemo(() => {
+    if (!isClubWideGroup) return null;
+    return calculateClubLedgerSummary(rows, rows, financialAccounts);
+  }, [rows, isClubWideGroup, financialAccounts]);
+
   // --- フィルタ + ソート ---
   const processedRows = useMemo(() => {
     let result = [...rows];
@@ -228,6 +266,16 @@ export default function LedgerView({
 
     if (filterStatus !== "all") {
       result = result.filter((r) => r.approval_status === filterStatus);
+    }
+
+    if (filterAccountId !== "all") {
+      result = result.filter(
+        (r) => r.financial_account_id === filterAccountId,
+      );
+    }
+
+    if (filterKind !== "all") {
+      result = result.filter((r) => r.transaction_kind === filterKind);
     }
 
     if (sortKey && sortDir) {
@@ -269,7 +317,7 @@ export default function LedgerView({
     }
 
     return result;
-  }, [rows, filterText, filterStatus, sortKey, sortDir]);
+  }, [rows, filterText, filterStatus, filterAccountId, filterKind, sortKey, sortDir]);
 
   // --- 描画 ---
   return (
@@ -308,11 +356,18 @@ export default function LedgerView({
       </div>
 
       {/* サマリーカード */}
-      <LedgerSummary
-        budgetAmount={budgetAmount}
-        carryoverAmount={carryoverAmount}
-        totals={totals}
-      />
+      {isClubWideGroup && clubSummary ? (
+        <ClubLedgerSummary
+          summary={clubSummary}
+          financialAccounts={financialAccounts}
+        />
+      ) : (
+        <LedgerSummary
+          budgetAmount={budgetAmount}
+          carryoverAmount={carryoverAmount}
+          totals={totals}
+        />
+      )}
 
       {/* 取引一覧 */}
       <Card>
@@ -328,6 +383,15 @@ export default function LedgerView({
             onFilterTextChange={setFilterText}
             filterStatus={filterStatus}
             onFilterStatusChange={setFilterStatus}
+            financialAccounts={
+              isClubWideGroup ? financialAccounts : undefined
+            }
+            filterAccountId={filterAccountId}
+            onFilterAccountChange={
+              isClubWideGroup ? setFilterAccountId : undefined
+            }
+            filterKind={filterKind}
+            onFilterKindChange={isClubWideGroup ? setFilterKind : undefined}
           />
 
           {/* モバイル表示 */}
@@ -341,6 +405,7 @@ export default function LedgerView({
             userRoleStr={userRoleStr}
             users={users}
             accountingUserId={accountingUserId}
+            showExtendedColumns={isClubWideGroup}
           />
 
           {/* デスクトップ表示 */}
@@ -357,6 +422,7 @@ export default function LedgerView({
             userRoleStr={userRoleStr}
             users={users}
             accountingUserId={accountingUserId}
+            showExtendedColumns={isClubWideGroup}
           />
         </CardContent>
       </Card>

--- a/components/ledger/club-ledger-summary.tsx
+++ b/components/ledger/club-ledger-summary.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Club-wide ledger summary cards.
+ * Shows: income, expense, balance, wallet balances, and transfer total.
+ */
+
+import { formatCurrency } from "@/lib/format";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ClubLedgerSummary as ClubSummaryType } from "@/lib/ledger";
+import type { FinancialAccountInfo } from "./types";
+
+type Props = {
+  summary: ClubSummaryType;
+  financialAccounts: FinancialAccountInfo[];
+};
+
+export function ClubLedgerSummary({ summary, financialAccounts }: Props) {
+  const totalBalance = Object.values(summary.walletBalances).reduce(
+    (sum, v) => sum + v,
+    0,
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>部全体集計</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Income / Expense / Balance */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="bg-muted rounded p-4">
+            <div className="text-sm text-muted-foreground">部全体収入</div>
+            <div className="text-xl font-semibold text-green-600">
+              {formatCurrency(summary.income)}
+            </div>
+          </div>
+          <div className="bg-muted rounded p-4">
+            <div className="text-sm text-muted-foreground">部全体支出</div>
+            <div className="text-xl font-semibold text-red-600">
+              {formatCurrency(summary.expense)}
+            </div>
+          </div>
+          <div className="bg-muted rounded p-4">
+            <div className="text-sm text-muted-foreground">収支差額</div>
+            <div
+              className={`text-xl font-semibold ${summary.balance < 0 ? "text-red-600" : ""}`}
+            >
+              {formatCurrency(summary.balance)}
+            </div>
+          </div>
+        </div>
+
+        {/* Wallet balances */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {financialAccounts.map((fa) => (
+            <div key={fa.id} className="bg-muted rounded p-4">
+              <div className="text-sm text-muted-foreground">
+                {fa.name}残高
+              </div>
+              <div className="text-xl font-semibold">
+                {formatCurrency(summary.walletBalances[fa.id] || 0)}
+              </div>
+            </div>
+          ))}
+          <div className="bg-muted rounded p-4">
+            <div className="text-sm text-muted-foreground">合計残高</div>
+            <div className="text-xl font-semibold">
+              {formatCurrency(totalBalance)}
+            </div>
+          </div>
+        </div>
+
+        {/* Transfer total */}
+        {summary.transferTotal > 0 && (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="bg-blue-50 dark:bg-blue-900/20 rounded p-4">
+              <div className="text-sm text-muted-foreground">
+                当年度資金移動総額
+              </div>
+              <div className="text-xl font-semibold text-blue-600">
+                {formatCurrency(summary.transferTotal)}
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/ledger/index.ts
+++ b/components/ledger/index.ts
@@ -2,7 +2,16 @@
  * 出納帳コンポーネント群のバレルエクスポート。
  */
 export { LedgerSummary } from "./ledger-summary";
+export { ClubLedgerSummary } from "./club-ledger-summary";
 export { LedgerFilterBar } from "./ledger-filter-bar";
 export { LedgerDesktopTable } from "./ledger-desktop-table";
 export { LedgerMobileCards } from "./ledger-mobile-cards";
-export type { LedgerTransaction, LedgerInitialData, Team, SortKey, SortDir } from "./types";
+export type {
+  LedgerTransaction,
+  LedgerInitialData,
+  FinancialAccountInfo,
+  Team,
+  SortKey,
+  SortDir,
+} from "./types";
+export { TRANSACTION_KIND_LABELS } from "./types";

--- a/components/ledger/ledger-desktop-table.tsx
+++ b/components/ledger/ledger-desktop-table.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import type { LedgerTransaction, SortKey, SortDir } from "./types";
+import { TRANSACTION_KIND_LABELS } from "./types";
 
 // ---------------------------------------------------------------------------
 // ソート可能なヘッダーセル
@@ -85,6 +86,8 @@ type Props = {
   userRoleStr: "admin" | "accounting" | "general";
   users?: { id: string; name: string }[];
   accountingUserId?: string;
+  /** Show financial account and transaction kind columns */
+  showExtendedColumns?: boolean;
 };
 
 export function LedgerDesktopTable({
@@ -100,6 +103,7 @@ export function LedgerDesktopTable({
   userRoleStr,
   users,
   accountingUserId,
+  showExtendedColumns = false,
 }: Props) {
   return (
     <div className="hidden xl:block">
@@ -127,6 +131,12 @@ export function LedgerDesktopTable({
               currentSortDir={sortDir}
               onSort={onSort}
             />
+            {showExtendedColumns && (
+              <>
+                <TableHead>財布</TableHead>
+                <TableHead>種別</TableHead>
+              </>
+            )}
             <SortableHeader
               label="金額"
               sortKey="amount"
@@ -186,8 +196,29 @@ export function LedgerDesktopTable({
                       支援金
                     </Badge>
                   )}
+                  {r.transaction_kind === "transfer" && (
+                    <Badge
+                      variant="secondary"
+                      className="mr-1 bg-purple-100 text-purple-800 hover:bg-purple-100 border-none"
+                    >
+                      移動
+                    </Badge>
+                  )}
                   <span>{r.description || "-"}</span>
                 </TableCell>
+                {showExtendedColumns && (
+                  <>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {r.financial_account_name || "-"}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {r.transaction_kind
+                        ? TRANSACTION_KIND_LABELS[r.transaction_kind] ||
+                          r.transaction_kind
+                        : "-"}
+                    </TableCell>
+                  </>
+                )}
                 <TableCell className="text-right">
                   <span
                     className={

--- a/components/ledger/ledger-filter-bar.tsx
+++ b/components/ledger/ledger-filter-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * 出納帳のフィルタバー（テキスト検索・ステータスフィルタ・件数表示）。
+ * 出納帳のフィルタバー（テキスト検索・ステータスフィルタ・財布フィルタ・種別フィルタ・件数表示）。
  */
 
 import { Input } from "@/components/ui/input";
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import type { FinancialAccountInfo } from "./types";
 
 type Props = {
   loading: boolean;
@@ -21,6 +22,12 @@ type Props = {
   onFilterTextChange: (text: string) => void;
   filterStatus: string;
   onFilterStatusChange: (status: string) => void;
+  /** Financial accounts for wallet filter. When empty/undefined, the filter is hidden. */
+  financialAccounts?: FinancialAccountInfo[];
+  filterAccountId?: string;
+  onFilterAccountChange?: (accountId: string) => void;
+  filterKind?: string;
+  onFilterKindChange?: (kind: string) => void;
 };
 
 export function LedgerFilterBar({
@@ -31,7 +38,16 @@ export function LedgerFilterBar({
   onFilterTextChange,
   filterStatus,
   onFilterStatusChange,
+  financialAccounts,
+  filterAccountId,
+  onFilterAccountChange,
+  filterKind,
+  onFilterKindChange,
 }: Props) {
+  const showAccountFilter =
+    financialAccounts && financialAccounts.length > 0 && onFilterAccountChange;
+  const showKindFilter = !!onFilterKindChange;
+
   return (
     <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 mb-4">
       <div className="text-sm text-muted-foreground">
@@ -39,18 +55,47 @@ export function LedgerFilterBar({
           ? "読み込み中..."
           : `${filteredCount}件${filteredCount !== totalCount ? ` / ${totalCount}件中` : ""}`}
       </div>
-      <div className="flex gap-2 w-full sm:w-auto">
+      <div className="flex gap-2 w-full sm:w-auto flex-wrap">
         <Input
           placeholder="検索..."
           value={filterText}
           onChange={(e) => onFilterTextChange(e.target.value)}
           className="h-8 w-full sm:w-48"
         />
-        {/* 将来拡張(部全体会計): ステータスフィルタの前に財布フィルタ (金庫/銀行口座/全財布)
-            と種別フィルタ (収入/支出/資金移動) の Select を追加する。
-            Props に onFilterAccountChange / onFilterKindChange を追加し、
-            LedgerView 側で useMemo のフィルタ条件に組み込む。
-            cf. docs/club-wide-ledger-spec.md */}
+        {showAccountFilter && (
+          <Select
+            value={filterAccountId || "all"}
+            onValueChange={onFilterAccountChange}
+          >
+            <SelectTrigger className="h-8 w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全財布</SelectItem>
+              {financialAccounts.map((fa) => (
+                <SelectItem key={fa.id} value={fa.id}>
+                  {fa.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        {showKindFilter && (
+          <Select
+            value={filterKind || "all"}
+            onValueChange={onFilterKindChange}
+          >
+            <SelectTrigger className="h-8 w-28">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">全種別</SelectItem>
+              <SelectItem value="income">収入</SelectItem>
+              <SelectItem value="expense">支出</SelectItem>
+              <SelectItem value="transfer">資金移動</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
         <Select value={filterStatus} onValueChange={onFilterStatusChange}>
           <SelectTrigger className="h-8 w-32">
             <SelectValue />

--- a/components/ledger/ledger-mobile-cards.tsx
+++ b/components/ledger/ledger-mobile-cards.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import type { LedgerTransaction } from "./types";
+import { TRANSACTION_KIND_LABELS } from "./types";
 
 type Props = {
   rows: LedgerTransaction[];
@@ -35,6 +36,7 @@ type Props = {
   userRoleStr: "admin" | "accounting" | "general";
   users?: { id: string; name: string }[];
   accountingUserId?: string;
+  showExtendedColumns?: boolean;
 };
 
 export function LedgerMobileCards({
@@ -47,6 +49,7 @@ export function LedgerMobileCards({
   userRoleStr,
   users,
   accountingUserId,
+  showExtendedColumns = false,
 }: Props) {
   const [openCards, setOpenCards] = useState<Set<string>>(new Set());
 
@@ -148,6 +151,29 @@ export function LedgerMobileCards({
                 </div>
 
                 <CollapsibleContent className="space-y-3 pt-1">
+                  {showExtendedColumns && (
+                    <div className="flex gap-4 text-sm">
+                      {r.financial_account_name && (
+                        <div>
+                          <span className="text-muted-foreground font-medium">
+                            財布:{" "}
+                          </span>
+                          <span>{r.financial_account_name}</span>
+                        </div>
+                      )}
+                      {r.transaction_kind && (
+                        <div>
+                          <span className="text-muted-foreground font-medium">
+                            種別:{" "}
+                          </span>
+                          <span>
+                            {TRANSACTION_KIND_LABELS[r.transaction_kind] ||
+                              r.transaction_kind}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  )}
                   {r.remarks && (
                     <div className="text-sm">
                       <span className="text-muted-foreground font-medium">

--- a/components/ledger/types.ts
+++ b/components/ledger/types.ts
@@ -2,7 +2,11 @@
  * 出納帳コンポーネント群で共有する型定義。
  */
 
-export type { LedgerTransaction, LedgerInitialData } from "@/lib/ledger";
+export type {
+  LedgerTransaction,
+  LedgerInitialData,
+  FinancialAccountInfo,
+} from "@/lib/ledger";
 
 export type Team = { id: string; name: string; type: "general" | "leader" };
 
@@ -15,3 +19,10 @@ export type SortKey =
   | "approved_by_name";
 
 export type SortDir = "asc" | "desc" | null;
+
+/** Transaction kind display labels (Japanese) */
+export const TRANSACTION_KIND_LABELS: Record<string, string> = {
+  income: "収入",
+  expense: "支出",
+  transfer: "資金移動",
+} as const;

--- a/components/transaction-form.tsx
+++ b/components/transaction-form.tsx
@@ -87,6 +87,11 @@ type TransactionData = {
   approved_by?: string | null;
 };
 
+type FinancialAccount = {
+  id: string;
+  name: string;
+};
+
 type Props = {
   categories: Category[];
   initialData?: TransactionData;
@@ -96,6 +101,9 @@ type Props = {
   userRole?: "admin" | "accounting" | "general" | null;
   users?: { id: string; name: string }[];
   accountingUserId?: string;
+  financialAccounts?: FinancialAccount[];
+  /** Default financial_account_id to pre-select */
+  defaultFinancialAccountId?: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -111,6 +119,8 @@ function TransactionFormInner({
   users,
   accountingUserId,
   onClose,
+  financialAccounts,
+  defaultFinancialAccountId,
 }: {
   categories: Category[];
   initialData?: TransactionData;
@@ -118,6 +128,8 @@ function TransactionFormInner({
   users?: { id: string; name: string }[];
   accountingUserId: string;
   onClose: () => void;
+  financialAccounts?: FinancialAccount[];
+  defaultFinancialAccountId?: string;
 }) {
   const [file, setFile] = useState<File | null>(null);
   const [isUploading, setIsUploading] = useState(false);
@@ -133,6 +145,11 @@ function TransactionFormInner({
             amount: Math.abs(initialData.amount),
             type: (initialData.amount < 0 ? "expense" : "income") as FormValues["type"],
             accounting_group_id: initialData.accounting_group_id ?? "",
+            financial_account_id:
+              (initialData as Record<string, unknown>).financial_account_id as string ??
+              defaultFinancialAccountId ??
+              financialAccounts?.[0]?.id ??
+              "",
             description: initialData.description ?? "",
             remarks: initialData.remarks || "",
             created_by: initialData.created_by ?? undefined,
@@ -144,10 +161,14 @@ function TransactionFormInner({
             amount: 0,
             type: "expense",
             accounting_group_id: "",
+            financial_account_id:
+              defaultFinancialAccountId ??
+              financialAccounts?.[0]?.id ??
+              "",
             description: "",
             remarks: "",
           },
-    [initialData],
+    [initialData, financialAccounts, defaultFinancialAccountId],
   );
 
   const form = useForm<FormValues>({
@@ -340,10 +361,6 @@ function TransactionFormInner({
         </div>
 
         {/* 会計グループ */}
-        {/* 将来拡張(部全体会計): この直後に financial_account_id (財布選択) と
-            transaction_kind (収入/支出/資金移動) フィールドを追加する。
-            資金移動時は別フォーム (TransferForm) への切替も検討。
-            cf. docs/club-wide-ledger-spec.md */}
         <FormField
           control={form.control}
           name="accounting_group_id"
@@ -372,6 +389,37 @@ function TransactionFormInner({
             </FormItem>
           )}
         />
+
+        {/* 財布 (Financial Account) */}
+        {financialAccounts && financialAccounts.length > 0 && (
+          <FormField
+            control={form.control}
+            name="financial_account_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>財布</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="財布を選択してください" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {financialAccounts.map((fa) => (
+                      <SelectItem key={fa.id} value={fa.id}>
+                        {fa.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         {/* 概要 */}
         <FormField
@@ -450,6 +498,8 @@ export function TransactionForm({
   userRole,
   users,
   accountingUserId = ACCOUNTING_USER_ID_FALLBACK,
+  financialAccounts,
+  defaultFinancialAccountId,
 }: Props) {
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
@@ -491,6 +541,8 @@ export function TransactionForm({
             users={users}
             accountingUserId={accountingUserId}
             onClose={() => setOpen(false)}
+            financialAccounts={financialAccounts}
+            defaultFinancialAccountId={defaultFinancialAccountId}
           />
         )}
       </DialogContent>

--- a/components/transfer-form.tsx
+++ b/components/transfer-form.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+/**
+ * Transfer form dialog for creating fund transfers between financial accounts.
+ * Creates two transaction rows atomically via the create_transfer RPC.
+ */
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { CalendarIcon, Loader2 } from "lucide-react";
+import { format } from "date-fns";
+import { ja } from "date-fns/locale";
+import { useRouter } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+import { transferFormSchema } from "@/lib/schema";
+import { parseDateInputValue } from "@/lib/date";
+import { formatDateForDatabase } from "@/lib/date";
+import { createTransfer } from "@/app/(authenticated)/ledger/actions";
+
+type FinancialAccount = {
+  id: string;
+  name: string;
+};
+
+type Props = {
+  financialAccounts: FinancialAccount[];
+  triggerButton?: React.ReactNode;
+};
+
+type TransferFormValues = z.infer<typeof transferFormSchema>;
+
+function TransferFormInner({
+  financialAccounts,
+  onClose,
+}: {
+  financialAccounts: FinancialAccount[];
+  onClose: () => void;
+}) {
+  const router = useRouter();
+
+  const form = useForm<TransferFormValues>({
+    resolver: zodResolver(transferFormSchema),
+    defaultValues: {
+      date: new Date(),
+      amount: 0,
+      from_account_id: "",
+      to_account_id: "",
+      description: "",
+      remarks: "",
+    },
+  });
+
+  async function onSubmit(values: TransferFormValues) {
+    try {
+      const result = await createTransfer({
+        date: formatDateForDatabase(values.date),
+        amount: values.amount,
+        fromAccountId: values.from_account_id,
+        toAccountId: values.to_account_id,
+        description: values.description,
+        receiptUrl: values.receipt_url ?? null,
+        remarks: values.remarks ?? null,
+      });
+
+      if ("error" in result) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success("資金移動を登録しました");
+      form.reset();
+      onClose();
+      window.dispatchEvent(new Event("ledger-refresh"));
+      router.refresh();
+    } catch (error) {
+      console.error("Transfer submit error:", error);
+      toast.error("予期せぬエラーが発生しました");
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {/* Date */}
+        <FormField
+          control={form.control}
+          name="date"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <FormLabel>日付</FormLabel>
+              <div className="flex gap-2 items-center">
+                <FormControl>
+                  <Input
+                    type="text"
+                    placeholder="2024/01/01"
+                    value={
+                      field.value ? format(field.value, "yyyy/MM/dd") : ""
+                    }
+                    onChange={(e) => {
+                      const parsed = parseDateInputValue(e.target.value);
+                      if (parsed) {
+                        field.onChange(parsed);
+                      }
+                    }}
+                    className="w-[140px]"
+                  />
+                </FormControl>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <Button variant="outline" size="icon">
+                      <CalendarIcon className="h-4 w-4" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-0" align="start">
+                    <Calendar
+                      mode="single"
+                      selected={field.value}
+                      onSelect={field.onChange}
+                      disabled={(date) =>
+                        date > new Date() || date < new Date("1900-01-01")
+                      }
+                      locale={ja}
+                      initialFocus
+                    />
+                  </PopoverContent>
+                </Popover>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* From / To accounts */}
+        <div className="grid grid-cols-2 gap-4">
+          <FormField
+            control={form.control}
+            name="from_account_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>移動元財布</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {financialAccounts.map((fa) => (
+                      <SelectItem key={fa.id} value={fa.id}>
+                        {fa.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="to_account_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>移動先財布</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="選択" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {financialAccounts.map((fa) => (
+                      <SelectItem key={fa.id} value={fa.id}>
+                        {fa.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Amount */}
+        <FormField
+          control={form.control}
+          name="amount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>金額 (円)</FormLabel>
+              <FormControl>
+                <Input type="number" placeholder="10000" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Description */}
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>摘要</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="例: 銀行口座から金庫へ移動"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Remarks */}
+        <FormField
+          control={form.control}
+          name="remarks"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>備考 (任意)</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="追加のメモ"
+                  {...field}
+                  value={field.value || ""}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={form.formState.isSubmitting}
+        >
+          {form.formState.isSubmitting && (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          )}
+          資金移動を登録
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+export function TransferForm({
+  financialAccounts,
+  triggerButton,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [formKey, setFormKey] = useState(0);
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setFormKey((k) => k + 1);
+    }
+    setOpen(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        {triggerButton || (
+          <Button variant="outline">資金移動</Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[500px] max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>資金移動の登録</DialogTitle>
+          <DialogDescription>
+            金庫と銀行口座間の資金移動を記録します。
+          </DialogDescription>
+        </DialogHeader>
+
+        {open && (
+          <TransferFormInner
+            key={formKey}
+            financialAccounts={financialAccounts}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/auth/permissions.ts
+++ b/lib/auth/permissions.ts
@@ -42,3 +42,51 @@ export async function verifyManageMembersPermission(
   }
   return { ok: true };
 }
+
+// ---------------------------------------------------------------------------
+// Club-wide ledger permissions (部全体会計)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if user can view the club-wide ledger (部全体会計).
+ * Only accounting staff and admins per the spec decision.
+ */
+export function canViewClubLedger(access: RoleAccessContext): boolean {
+  return access.isAdmin || access.hasAccountingRole;
+}
+
+/**
+ * Check if user can create/edit club-wide transactions.
+ * Only accounting staff and admins.
+ */
+export function canCreateClubTransaction(access: RoleAccessContext): boolean {
+  return access.isAdmin || access.hasAccountingRole;
+}
+
+/**
+ * Check if user can manage financial account master data.
+ * Only admins.
+ */
+export function canManageFinancialAccounts(
+  access: RoleAccessContext,
+): boolean {
+  return access.isAdmin;
+}
+
+/**
+ * Verify that the user has permission to write club-wide transactions.
+ * Returns PermissionCheckResult for use in server actions.
+ */
+export async function verifyClubTransactionPermission(
+  auth: AuthContext,
+  access?: RoleAccessContext,
+): Promise<PermissionCheckResult> {
+  const roleAccess = access ?? (await getUserRoleAccess(auth));
+  if (!canCreateClubTransaction(roleAccess)) {
+    return {
+      ok: false,
+      error: "部全体取引の作成には会計担当または管理者権限が必要です",
+    };
+  }
+  return { ok: true };
+}

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -66,6 +66,36 @@ export type Database = {
         }
         Relationships: []
       }
+      financial_accounts: {
+        Row: {
+          created_at: string
+          display_order: number
+          id: string
+          is_active: boolean
+          name: string
+          type: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          name: string
+          type: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          display_order?: number
+          id?: string
+          is_active?: boolean
+          name?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       audit_logs: {
         Row: {
           action: string
@@ -366,12 +396,15 @@ export type Database = {
           date: string
           deleted_at: string | null
           description: string
+          financial_account_id: string
           fiscal_year_id: number | null
           id: string
           receipt_url: string | null
           rejected_reason: string | null
           remarks: string | null
           subsidy_item_id: string | null
+          transaction_kind: Database["public"]["Enums"]["transaction_kind"]
+          transfer_id: string | null
           updated_at: string | null
         }
         Insert: {
@@ -385,12 +418,15 @@ export type Database = {
           date: string
           deleted_at?: string | null
           description: string
+          financial_account_id: string
           fiscal_year_id?: number | null
           id?: string
           receipt_url?: string | null
           rejected_reason?: string | null
           remarks?: string | null
           subsidy_item_id?: string | null
+          transaction_kind: Database["public"]["Enums"]["transaction_kind"]
+          transfer_id?: string | null
           updated_at?: string | null
         }
         Update: {
@@ -404,12 +440,15 @@ export type Database = {
           date?: string
           deleted_at?: string | null
           description?: string
+          financial_account_id?: string
           fiscal_year_id?: number | null
           id?: string
           receipt_url?: string | null
           rejected_reason?: string | null
           remarks?: string | null
           subsidy_item_id?: string | null
+          transaction_kind?: Database["public"]["Enums"]["transaction_kind"]
+          transfer_id?: string | null
           updated_at?: string | null
         }
         Relationships: [
@@ -446,6 +485,13 @@ export type Database = {
             columns: ["subsidy_item_id"]
             isOneToOne: false
             referencedRelation: "subsidy_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "transactions_financial_account_id_fkey"
+            columns: ["financial_account_id"]
+            isOneToOne: false
+            referencedRelation: "financial_accounts"
             referencedColumns: ["id"]
           },
         ]
@@ -499,12 +545,16 @@ export type Database = {
           created_by_name: string | null
           date: string | null
           description: string | null
+          financial_account_id: string | null
+          financial_account_name: string | null
           fiscal_year_id: number | null
           id: string | null
           receipt_url: string | null
           rejected_reason: string | null
           remarks: string | null
           subsidy_item_id: string | null
+          transaction_kind: string | null
+          transfer_id: string | null
         }
         Relationships: [
           {
@@ -546,6 +596,19 @@ export type Database = {
       }
     }
     Functions: {
+      create_transfer: {
+        Args: {
+          p_date: string
+          p_amount: number
+          p_from_account_id: string
+          p_to_account_id: string
+          p_description: string
+          p_receipt_url?: string | null
+          p_remarks?: string | null
+          p_created_by?: string | null
+        }
+        Returns: string
+      }
       get_budget_usage: {
         Args: { p_fiscal_year_id: number }
         Returns: {
@@ -556,7 +619,9 @@ export type Database = {
         }[]
       }
       has_role: { Args: { role_name: string }; Returns: boolean }
+      is_accounting_or_admin: { Args: never; Returns: boolean }
       is_admin: { Args: never; Returns: boolean }
+      is_club_group: { Args: { p_accounting_group_id: string }; Returns: boolean }
     }
     Enums: {
       approval_status:
@@ -590,6 +655,7 @@ export type Database = {
         | "application_rejected"
         | "accounting_received"
         | "application_in_progress"
+      transaction_kind: "income" | "expense" | "transfer"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -754,6 +820,7 @@ export const Constants = {
         "accounting_received",
         "application_in_progress",
       ],
+      transaction_kind: ["income", "expense", "transfer"],
     },
   },
 } as const

--- a/lib/ledger.ts
+++ b/lib/ledger.ts
@@ -33,6 +33,10 @@ export type TransactionRow = {
   is_subsidy?: boolean;
   subsidy_id?: string;
   subsidy_item_id?: string | null;
+  financial_account_id?: string | null;
+  financial_account_name?: string | null;
+  transaction_kind?: string | null;
+  transfer_id?: string | null;
 };
 
 /**
@@ -56,6 +60,10 @@ export type LedgerTransaction = {
   accounting_group_id?: string | null;
   receipt_url?: string | null;
   approved_by?: string | null;
+  financial_account_id?: string | null;
+  financial_account_name?: string | null;
+  transaction_kind?: string | null;
+  transfer_id?: string | null;
 };
 
 /**
@@ -192,7 +200,7 @@ export type AggregateOptions = {
   financialAccountId?: string;
 };
 
-type AmountLike = { amount: number; transaction_kind?: string; financial_account_id?: string };
+type AmountLike = { amount: number; transaction_kind?: string | null; financial_account_id?: string | null; approval_status?: string | null };
 
 /**
  * 集計対象の行を options に基づいてフィルタリングする内部ヘルパー。
@@ -258,4 +266,73 @@ export function calculateLedgerTotals(
     income -
     expense;
   return { income, expense, budgetRemaining };
+}
+
+// ---------------------------------------------------------------------------
+// Club-wide ledger summary helpers
+// ---------------------------------------------------------------------------
+
+export type FinancialAccountInfo = {
+  id: string;
+  name: string;
+};
+
+export type ClubLedgerSummary = {
+  income: number;
+  expense: number;
+  balance: number;
+  transferTotal: number;
+  walletBalances: Record<string, number>;
+};
+
+/**
+ * Calculate the club-wide ledger summary.
+ *
+ * - income/expense: only approved, non-transfer rows in the current fiscal year
+ * - walletBalances: cumulative across all years up to the selected fiscal year
+ *   (caller must pass allRows including historical data for balance calculation)
+ * - transferTotal: sum of absolute positive amounts of approved transfer rows
+ *   in the current fiscal year
+ */
+export function calculateClubLedgerSummary(
+  currentYearRows: readonly AmountLike[],
+  allRowsForBalance: readonly AmountLike[],
+  financialAccounts: readonly FinancialAccountInfo[],
+): ClubLedgerSummary {
+  // Income/expense: exclude transfers, only approved rows
+  const nonTransferApproved = currentYearRows.filter(
+    (r) =>
+      r.transaction_kind !== "transfer" &&
+      r.approval_status !== "rejected" &&
+      r.approval_status !== "pending",
+  );
+  const income = calculateIncomeTotal(nonTransferApproved);
+  const expense = calculateExpenseTotal(nonTransferApproved);
+  const balance = income - expense;
+
+  // Transfer total for current year: sum of positive approved transfer amounts
+  const transferTotal = currentYearRows
+    .filter(
+      (r) =>
+        r.transaction_kind === "transfer" &&
+        r.amount > 0 &&
+        r.approval_status !== "rejected" &&
+        r.approval_status !== "pending",
+    )
+    .reduce((sum, r) => sum + r.amount, 0);
+
+  // Wallet balances: cumulative across all rows (all years), approved only
+  const walletBalances: Record<string, number> = {};
+  for (const fa of financialAccounts) {
+    walletBalances[fa.id] = 0;
+  }
+  for (const r of allRowsForBalance) {
+    if (r.approval_status === "rejected" || r.approval_status === "pending") continue;
+    const faId = r.financial_account_id;
+    if (faId && faId in walletBalances) {
+      walletBalances[faId] += Number(r.amount) || 0;
+    }
+  }
+
+  return { income, expense, balance, transferTotal, walletBalances };
 }

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -18,8 +18,10 @@ export const formSchema = z.object({
   accounting_group_id: z.string({
     required_error: "会計グループを選択してください",
   }),
+  financial_account_id: z.string({
+    required_error: "財布を選択してください",
+  }),
   description: z.string().min(1, "摘要を入力してください"),
-  // 将来拡張(部全体会計): financial_account_id と transaction_kind を optional フィールドとして追加予定
   // 領収書URL（任意）
   receipt_url: z.string().nullable().optional(),
   // 備考（任意）
@@ -41,6 +43,27 @@ export const formSchema = z.object({
     ])
     .optional(),
 });
+
+export const transferFormSchema = z
+  .object({
+    date: z.date({
+      required_error: "日付を選択してください",
+    }),
+    amount: z.coerce.number().min(1, "金額は1円以上で入力してください"),
+    from_account_id: z.string({
+      required_error: "移動元財布を選択してください",
+    }),
+    to_account_id: z.string({
+      required_error: "移動先財布を選択してください",
+    }),
+    description: z.string().min(1, "摘要を入力してください"),
+    receipt_url: z.string().nullable().optional(),
+    remarks: z.string().nullable().optional(),
+  })
+  .refine((data) => data.from_account_id !== data.to_account_id, {
+    message: "移動元と移動先は異なる財布を選択してください",
+    path: ["to_account_id"],
+  });
 
 export const subsidyFormSchema = z.object({
   category: z.enum(["activity", "league", "special"], {

--- a/lib/teams.ts
+++ b/lib/teams.ts
@@ -71,7 +71,8 @@ export async function getUserTeams(
 
   if (isFullAccess) {
     safeCategories.forEach((c) => {
-      myTeams.push({ id: c.id, name: c.name, type: ROLE_TYPES.GENERAL as "general" });
+      // Include club-type groups for full-access users (accounting/admin)
+      myTeams.push({ id: c.id, name: c.name, type: (c.type === "leader" ? "leader" : c.type === "club" ? "general" : "general") as "general" | "leader" });
     });
   } else {
     // 全ユーザーに general タイプのグループを表示

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -196,6 +196,30 @@ export const createAccountingGroupSchema = z.object({
   type: z.string().min(1, "Group type is required").max(100),
 });
 
+/** createTransfer */
+export const createTransferSchema = z
+  .object({
+    date: z.string().min(1, "Date is required"),
+    amount: z.number().int().min(1, "Amount must be positive"),
+    fromAccountId: uuidSchema,
+    toAccountId: uuidSchema,
+    description: z.string().min(1, "Description is required"),
+    receiptUrl: z.string().nullable().optional(),
+    remarks: z.string().nullable().optional(),
+  })
+  .refine((data) => data.fromAccountId !== data.toAccountId, {
+    message: "Source and destination accounts must be different",
+    path: ["toAccountId"],
+  });
+
+/** fetchLedgerTransactions (extended with financial account and kind filters) */
+export const fetchClubLedgerTransactionsSchema = z.object({
+  accountingGroupId: uuidSchema,
+  fyYear: z.number().int().optional(),
+  financialAccountId: uuidSchema.optional(),
+  transactionKind: z.enum(["income", "expense", "transfer"]).optional(),
+});
+
 // --- Utility: Safe validation wrapper ---
 
 export type ValidationResult<T> =

--- a/supabase/migrations/20260612120000_add_club_wide_ledger.sql
+++ b/supabase/migrations/20260612120000_add_club_wide_ledger.sql
@@ -1,0 +1,393 @@
+-- Migration: Add club-wide ledger with financial accounts and transfer support
+-- Purpose:
+--   1. Create financial_accounts table (wallets: cash box, bank account)
+--   2. Add 部全体 accounting group (type=club)
+--   3. Add financial_account_id, transaction_kind, transfer_id to transactions
+--   4. Backfill existing transactions with default financial account and kind
+--   5. Update ledger view with new columns
+--   6. Update get_budget_usage to exclude transfers
+--   7. Add create_transfer RPC for atomic 2-row transfer insertion
+--   8. Add RLS policies for financial_accounts and club-wide transactions
+
+-- =============================================================================
+-- 1. financial_accounts table
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.financial_accounts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  type TEXT NOT NULL CHECK (type IN ('cash', 'bank', 'other')),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  display_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed initial financial accounts
+INSERT INTO public.financial_accounts (name, type, display_order)
+VALUES
+  ('金庫', 'cash', 10),
+  ('銀行口座', 'bank', 20)
+ON CONFLICT (name) DO NOTHING;
+
+-- =============================================================================
+-- 2. Add 部全体 accounting group (type=club)
+-- =============================================================================
+
+-- accounting_groups.type has no CHECK constraint or enum -- it uses free-text
+-- with convention values 'general', 'leader'. We add 'club' for club-wide.
+INSERT INTO public.accounting_groups (name, type, is_active)
+VALUES ('部全体', 'club', TRUE)
+ON CONFLICT (name) DO NOTHING;
+
+-- Ensure is_active and updated_at columns exist on accounting_groups
+-- (they may have been added by a later migration)
+ALTER TABLE public.accounting_groups
+  ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE public.accounting_groups
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+
+-- =============================================================================
+-- 3. Add new columns to transactions
+-- =============================================================================
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS financial_account_id UUID REFERENCES public.financial_accounts(id);
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS transaction_kind TEXT;
+
+ALTER TABLE public.transactions
+  ADD COLUMN IF NOT EXISTS transfer_id UUID;
+
+-- =============================================================================
+-- 4. Backfill existing transactions
+-- =============================================================================
+
+-- Set financial_account_id to 金庫 for all existing rows that lack it
+UPDATE public.transactions
+SET financial_account_id = (
+  SELECT id FROM public.financial_accounts WHERE name = '金庫' LIMIT 1
+)
+WHERE financial_account_id IS NULL;
+
+-- Derive transaction_kind from amount sign for existing rows
+UPDATE public.transactions
+SET transaction_kind = CASE
+  WHEN amount >= 0 THEN 'income'
+  ELSE 'expense'
+END
+WHERE transaction_kind IS NULL;
+
+-- =============================================================================
+-- 5. Set NOT NULL and CHECK constraints after backfill
+-- =============================================================================
+
+ALTER TABLE public.transactions
+  ALTER COLUMN financial_account_id SET NOT NULL;
+
+ALTER TABLE public.transactions
+  ALTER COLUMN transaction_kind SET NOT NULL;
+
+-- Add CHECK constraint for transaction_kind values
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'transactions_transaction_kind_check'
+  ) THEN
+    ALTER TABLE public.transactions
+      ADD CONSTRAINT transactions_transaction_kind_check
+      CHECK (transaction_kind IN ('income', 'expense', 'transfer'));
+  END IF;
+END $$;
+
+-- Add indexes for new columns
+CREATE INDEX IF NOT EXISTS idx_transactions_financial_account
+  ON public.transactions(financial_account_id);
+CREATE INDEX IF NOT EXISTS idx_transactions_transaction_kind
+  ON public.transactions(transaction_kind);
+CREATE INDEX IF NOT EXISTS idx_transactions_transfer_id
+  ON public.transactions(transfer_id);
+
+-- =============================================================================
+-- 6. Update ledger view to include new columns
+-- =============================================================================
+
+-- security_invoker so the transactions RLS (including the club-wide
+-- visibility restriction) applies when the view is queried directly.
+-- DROP first because CREATE OR REPLACE cannot reorder existing columns.
+DROP VIEW IF EXISTS v_ledger_transactions;
+CREATE VIEW v_ledger_transactions
+WITH (security_invoker = on) AS
+SELECT
+  t.id,
+  t.date,
+  t.amount,
+  t.description,
+  t.accounting_group_id,
+  t.approval_status,
+  t.receipt_url,
+  t.created_by,
+  t.approved_by,
+  t.rejected_reason,
+  t.remarks,
+  t.subsidy_item_id,
+  t.fiscal_year_id,
+  t.financial_account_id,
+  t.transaction_kind,
+  t.transfer_id,
+  fa.name AS financial_account_name,
+  p_creator.name AS created_by_name,
+  p_approver.name AS approved_by_name
+FROM transactions t
+LEFT JOIN financial_accounts fa ON t.financial_account_id = fa.id
+LEFT JOIN profiles p_creator ON t.created_by = p_creator.id
+LEFT JOIN profiles p_approver ON t.approved_by = p_approver.id;
+
+-- =============================================================================
+-- 7. Update get_budget_usage to exclude transfers
+-- =============================================================================
+
+DROP FUNCTION IF EXISTS public.get_budget_usage(integer);
+
+CREATE FUNCTION public.get_budget_usage(p_fiscal_year_id integer)
+RETURNS TABLE(accounting_group_id uuid, expenses numeric, pending numeric, income numeric)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH processed_subsidy_ids AS (
+    SELECT id FROM subsidy_items
+    WHERE fiscal_year_id = p_fiscal_year_id
+      AND status IN ('approved', 'receipt_submitted', 'paid')
+      AND deleted_at IS NULL
+  ),
+  subsidy_related_tx AS (
+    SELECT DISTINCT ON (t.subsidy_item_id)
+      t.subsidy_item_id, t.accounting_group_id
+    FROM transactions t
+    WHERE t.fiscal_year_id = p_fiscal_year_id
+      AND t.subsidy_item_id IS NOT NULL
+      AND t.deleted_at IS NULL
+    ORDER BY t.subsidy_item_id, t.created_at ASC
+  ),
+  tx_rows AS (
+    SELECT t.accounting_group_id, t.approval_status::text, t.amount
+    FROM transactions t
+    WHERE t.fiscal_year_id = p_fiscal_year_id
+      AND t.deleted_at IS NULL
+      AND t.transaction_kind <> 'transfer'
+      AND (t.subsidy_item_id IS NULL OR t.subsidy_item_id NOT IN (SELECT id FROM processed_subsidy_ids))
+  ),
+  subsidy_expense_rows AS (
+    SELECT COALESCE(rt.accounting_group_id, si.accounting_group_id), 'refunded'::text, -si.actual_amount
+    FROM subsidy_items si
+    LEFT JOIN subsidy_related_tx rt ON rt.subsidy_item_id = si.id
+    WHERE si.fiscal_year_id = p_fiscal_year_id
+      AND si.status IN ('approved', 'receipt_submitted', 'paid')
+      AND si.deleted_at IS NULL
+      AND COALESCE(si.actual_amount, 0) > 0
+  ),
+  subsidy_income_rows AS (
+    SELECT
+      COALESCE(rt.accounting_group_id, si.accounting_group_id),
+      CASE WHEN si.status = 'paid' THEN 'refunded' ELSE 'approved' END::text,
+      si.approved_amount
+    FROM subsidy_items si
+    LEFT JOIN subsidy_related_tx rt ON rt.subsidy_item_id = si.id
+    WHERE si.fiscal_year_id = p_fiscal_year_id
+      AND si.status IN ('approved', 'receipt_submitted', 'paid')
+      AND si.deleted_at IS NULL
+      AND COALESCE(si.approved_amount, 0) > 0
+  ),
+  all_rows AS (
+    SELECT * FROM tx_rows
+    UNION ALL
+    SELECT * FROM subsidy_expense_rows
+    UNION ALL
+    SELECT * FROM subsidy_income_rows
+  )
+  SELECT
+    all_rows.accounting_group_id,
+    COALESCE(SUM(
+      CASE
+        WHEN approval_status IN ('refunded', 'receipt_received', 'received') AND amount < 0 THEN ABS(amount)
+        ELSE 0
+      END
+    ), 0) AS expenses,
+    COALESCE(SUM(
+      CASE
+        WHEN approval_status IN ('pending', 'accepted', 'approved') AND amount < 0 THEN ABS(amount)
+        ELSE 0
+      END
+    ), 0) AS pending,
+    COALESCE(SUM(
+      CASE
+        WHEN amount > 0 AND approval_status NOT IN ('rejected') THEN amount
+        ELSE 0
+      END
+    ), 0) AS income
+  FROM all_rows
+  WHERE all_rows.accounting_group_id IS NOT NULL
+  GROUP BY all_rows.accounting_group_id;
+$$;
+
+-- =============================================================================
+-- 8. create_transfer RPC for atomic 2-row transfer insertion
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.create_transfer(
+  p_date DATE,
+  p_amount INTEGER,
+  p_from_account_id UUID,
+  p_to_account_id UUID,
+  p_description TEXT,
+  p_receipt_url TEXT DEFAULT NULL,
+  p_remarks TEXT DEFAULT NULL,
+  p_created_by UUID DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_transfer_id UUID := gen_random_uuid();
+  v_club_group_id UUID;
+  v_fiscal_year_id INTEGER;
+  -- auth.uid() is authoritative when called with a user JWT; p_created_by is
+  -- only honored for service-role calls where auth.uid() is NULL.
+  v_created_by UUID := COALESCE(auth.uid(), p_created_by);
+BEGIN
+  -- SECURITY DEFINER bypasses RLS, so enforce authorization here as well:
+  -- only accounting staff/admins (or service-role callers) may create transfers.
+  IF auth.uid() IS NOT NULL AND NOT is_accounting_or_admin() THEN
+    RAISE EXCEPTION 'Insufficient privileges to create a transfer';
+  END IF;
+
+  -- Validate: different accounts
+  IF p_from_account_id = p_to_account_id THEN
+    RAISE EXCEPTION 'Source and destination accounts must be different';
+  END IF;
+
+  -- Validate: positive amount
+  IF p_amount <= 0 THEN
+    RAISE EXCEPTION 'Transfer amount must be positive';
+  END IF;
+
+  -- Get the 部全体 accounting group
+  SELECT id INTO v_club_group_id
+  FROM accounting_groups
+  WHERE type = 'club'
+  LIMIT 1;
+
+  IF v_club_group_id IS NULL THEN
+    RAISE EXCEPTION 'Club-wide accounting group not found';
+  END IF;
+
+  -- Determine fiscal year from the date
+  SELECT year INTO v_fiscal_year_id
+  FROM fiscal_years
+  WHERE start_date <= p_date AND end_date >= p_date
+  LIMIT 1;
+
+  -- Insert the outgoing leg (negative amount from source)
+  INSERT INTO transactions (
+    id, date, amount, description, accounting_group_id,
+    fiscal_year_id, financial_account_id, transaction_kind, transfer_id,
+    receipt_url, remarks, created_by, approval_status
+  ) VALUES (
+    gen_random_uuid(), p_date, -p_amount, p_description, v_club_group_id,
+    v_fiscal_year_id, p_from_account_id, 'transfer', v_transfer_id,
+    p_receipt_url, p_remarks, v_created_by, 'pending'
+  );
+
+  -- Insert the incoming leg (positive amount to destination)
+  INSERT INTO transactions (
+    id, date, amount, description, accounting_group_id,
+    fiscal_year_id, financial_account_id, transaction_kind, transfer_id,
+    receipt_url, remarks, created_by, approval_status
+  ) VALUES (
+    gen_random_uuid(), p_date, p_amount, p_description, v_club_group_id,
+    v_fiscal_year_id, p_to_account_id, 'transfer', v_transfer_id,
+    p_receipt_url, p_remarks, v_created_by, 'pending'
+  );
+
+  RETURN v_transfer_id;
+END;
+$$;
+
+-- =============================================================================
+-- 9. RLS policies for financial_accounts
+-- =============================================================================
+
+ALTER TABLE public.financial_accounts ENABLE ROW LEVEL SECURITY;
+
+-- All authenticated users can read financial accounts
+CREATE POLICY "financial_accounts_select_authenticated"
+  ON public.financial_accounts FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Only admins can insert/update/delete financial accounts
+CREATE POLICY "financial_accounts_admin_all"
+  ON public.financial_accounts FOR ALL
+  TO authenticated
+  USING (is_admin());
+
+-- =============================================================================
+-- 10. RLS policies for club-wide (部全体) transactions
+-- =============================================================================
+
+-- Helper function: check if accounting group is club-wide
+CREATE OR REPLACE FUNCTION public.is_club_group(p_accounting_group_id UUID)
+RETURNS BOOLEAN AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.accounting_groups
+    WHERE id = p_accounting_group_id AND type = 'club'
+  );
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Helper function: check if current user is accounting staff or admin
+CREATE OR REPLACE FUNCTION public.is_accounting_or_admin()
+RETURNS BOOLEAN AS $$
+  SELECT is_admin() OR has_role('会計');
+$$ LANGUAGE sql SECURITY DEFINER STABLE;
+
+-- Update SELECT policy: club-wide transactions visible only to accounting/admin
+-- Drop existing policy and recreate to include club-wide restriction
+DROP POLICY IF EXISTS "transactions_select_non_deleted" ON public.transactions;
+
+CREATE POLICY "transactions_select_non_deleted"
+  ON public.transactions FOR SELECT
+  TO authenticated
+  USING (
+    deleted_at IS NULL
+    AND (
+      NOT is_club_group(accounting_group_id)
+      OR is_accounting_or_admin()
+    )
+  );
+
+-- Update INSERT policy: club-wide transactions only by accounting/admin
+DROP POLICY IF EXISTS "transactions_insert_member" ON public.transactions;
+
+CREATE POLICY "transactions_insert_member"
+  ON public.transactions FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    CASE
+      WHEN is_club_group(accounting_group_id) THEN
+        is_accounting_or_admin()
+      ELSE
+        EXISTS (
+          SELECT 1
+          FROM public.user_roles ur
+          JOIN public.roles r ON r.id = ur.role_id
+          WHERE ur.user_id = auth.uid()
+            AND r.accounting_group_id = accounting_group_id
+        )
+    END
+  );

--- a/tests/lib/club-ledger.test.ts
+++ b/tests/lib/club-ledger.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateIncomeTotal,
+  calculateExpenseTotal,
+  calculateClubLedgerSummary,
+  type FinancialAccountInfo,
+} from "@/lib/ledger";
+import {
+  canViewClubLedger,
+  canCreateClubTransaction,
+  canManageFinancialAccounts,
+} from "@/lib/auth/permissions";
+import type { RoleAccessContext } from "@/lib/roles/types";
+
+// ---------------------------------------------------------------------------
+// calculateClubLedgerSummary
+// ---------------------------------------------------------------------------
+
+describe("calculateClubLedgerSummary", () => {
+  const accounts: FinancialAccountInfo[] = [
+    { id: "cash", name: "金庫" },
+    { id: "bank", name: "銀行口座" },
+  ];
+
+  it("computes income and expense excluding transfers", () => {
+    const rows = [
+      { amount: 5000, transaction_kind: "income", financial_account_id: "cash", approval_status: "approved" },
+      { amount: -2000, transaction_kind: "expense", financial_account_id: "cash", approval_status: "approved" },
+      { amount: 3000, transaction_kind: "transfer", financial_account_id: "cash", approval_status: "approved" },
+      { amount: -3000, transaction_kind: "transfer", financial_account_id: "bank", approval_status: "approved" },
+    ];
+
+    const result = calculateClubLedgerSummary(rows, rows, accounts);
+    expect(result.income).toBe(5000);
+    expect(result.expense).toBe(2000);
+    expect(result.balance).toBe(3000);
+  });
+
+  it("excludes pending and rejected rows from income/expense", () => {
+    const rows = [
+      { amount: 1000, transaction_kind: "income", financial_account_id: "cash", approval_status: "approved" },
+      { amount: 2000, transaction_kind: "income", financial_account_id: "cash", approval_status: "pending" },
+      { amount: -500, transaction_kind: "expense", financial_account_id: "cash", approval_status: "rejected" },
+    ];
+
+    const result = calculateClubLedgerSummary(rows, rows, accounts);
+    expect(result.income).toBe(1000);
+    expect(result.expense).toBe(0);
+  });
+
+  it("calculates wallet balances across all approved transactions", () => {
+    const rows = [
+      { amount: 10000, transaction_kind: "income", financial_account_id: "cash", approval_status: "approved" },
+      { amount: -3000, transaction_kind: "expense", financial_account_id: "cash", approval_status: "approved" },
+      { amount: 5000, transaction_kind: "income", financial_account_id: "bank", approval_status: "approved" },
+      { amount: -2000, transaction_kind: "transfer", financial_account_id: "bank", approval_status: "approved" },
+      { amount: 2000, transaction_kind: "transfer", financial_account_id: "cash", approval_status: "approved" },
+    ];
+
+    const result = calculateClubLedgerSummary(rows, rows, accounts);
+    // cash: 10000 - 3000 + 2000 = 9000
+    expect(result.walletBalances["cash"]).toBe(9000);
+    // bank: 5000 - 2000 = 3000
+    expect(result.walletBalances["bank"]).toBe(3000);
+  });
+
+  it("transfer does not affect total balance", () => {
+    const rows = [
+      { amount: 10000, transaction_kind: "income", financial_account_id: "cash", approval_status: "approved" },
+      { amount: -5000, transaction_kind: "transfer", financial_account_id: "cash", approval_status: "approved" },
+      { amount: 5000, transaction_kind: "transfer", financial_account_id: "bank", approval_status: "approved" },
+    ];
+
+    const result = calculateClubLedgerSummary(rows, rows, accounts);
+    const totalBalance = Object.values(result.walletBalances).reduce((s, v) => s + v, 0);
+    // Total should be 10000 (income) - transfers cancel out
+    expect(totalBalance).toBe(10000);
+  });
+
+  it("calculates transfer total from positive approved transfer amounts", () => {
+    const rows = [
+      { amount: 3000, transaction_kind: "transfer", financial_account_id: "cash", approval_status: "approved" },
+      { amount: -3000, transaction_kind: "transfer", financial_account_id: "bank", approval_status: "approved" },
+      { amount: 2000, transaction_kind: "transfer", financial_account_id: "cash", approval_status: "pending" },
+    ];
+
+    const result = calculateClubLedgerSummary(rows, rows, accounts);
+    // Only the approved positive transfer counts
+    expect(result.transferTotal).toBe(3000);
+  });
+
+  it("handles empty rows", () => {
+    const result = calculateClubLedgerSummary([], [], accounts);
+    expect(result.income).toBe(0);
+    expect(result.expense).toBe(0);
+    expect(result.balance).toBe(0);
+    expect(result.transferTotal).toBe(0);
+    expect(result.walletBalances["cash"]).toBe(0);
+    expect(result.walletBalances["bank"]).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer exclusion in aggregate helpers
+// ---------------------------------------------------------------------------
+
+describe("aggregate helpers with transfers", () => {
+  it("excludeTransfers filters out transfer rows from income total", () => {
+    const rows = [
+      { amount: 1000, transaction_kind: "income" },
+      { amount: 500, transaction_kind: "transfer" },
+      { amount: 200, transaction_kind: "income" },
+    ];
+    expect(calculateIncomeTotal(rows, { excludeTransfers: true })).toBe(1200);
+    expect(calculateIncomeTotal(rows)).toBe(1700);
+  });
+
+  it("excludeTransfers filters out transfer rows from expense total", () => {
+    const rows = [
+      { amount: -1000, transaction_kind: "expense" },
+      { amount: -500, transaction_kind: "transfer" },
+    ];
+    expect(calculateExpenseTotal(rows, { excludeTransfers: true })).toBe(1000);
+    expect(calculateExpenseTotal(rows)).toBe(1500);
+  });
+
+  it("financialAccountId filter works with transfers", () => {
+    const rows = [
+      { amount: 1000, financial_account_id: "cash", transaction_kind: "income" },
+      { amount: 2000, financial_account_id: "bank", transaction_kind: "income" },
+      { amount: 500, financial_account_id: "cash", transaction_kind: "transfer" },
+    ];
+    expect(
+      calculateIncomeTotal(rows, {
+        financialAccountId: "cash",
+        excludeTransfers: true,
+      }),
+    ).toBe(1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permission helpers
+// ---------------------------------------------------------------------------
+
+describe("club ledger permissions", () => {
+  const adminAccess: RoleAccessContext = {
+    roles: [{ name: "admin", type: "admin", accountingGroupId: null }],
+    isAdmin: true,
+    hasAccountingRole: false,
+    canManageMembers: true,
+    groupRoleTypes: {},
+  };
+
+  const accountingAccess: RoleAccessContext = {
+    roles: [{ name: "会計", type: "accounting", accountingGroupId: null }],
+    isAdmin: false,
+    hasAccountingRole: true,
+    canManageMembers: true,
+    groupRoleTypes: {},
+  };
+
+  const generalAccess: RoleAccessContext = {
+    roles: [{ name: "一般", type: "general", accountingGroupId: "grp-1" }],
+    isAdmin: false,
+    hasAccountingRole: false,
+    canManageMembers: false,
+    groupRoleTypes: { "grp-1": ["general"] },
+  };
+
+  describe("canViewClubLedger", () => {
+    it("returns true for admin", () => {
+      expect(canViewClubLedger(adminAccess)).toBe(true);
+    });
+
+    it("returns true for accounting", () => {
+      expect(canViewClubLedger(accountingAccess)).toBe(true);
+    });
+
+    it("returns false for general user", () => {
+      expect(canViewClubLedger(generalAccess)).toBe(false);
+    });
+  });
+
+  describe("canCreateClubTransaction", () => {
+    it("returns true for admin", () => {
+      expect(canCreateClubTransaction(adminAccess)).toBe(true);
+    });
+
+    it("returns true for accounting", () => {
+      expect(canCreateClubTransaction(accountingAccess)).toBe(true);
+    });
+
+    it("returns false for general user", () => {
+      expect(canCreateClubTransaction(generalAccess)).toBe(false);
+    });
+  });
+
+  describe("canManageFinancialAccounts", () => {
+    it("returns true for admin", () => {
+      expect(canManageFinancialAccounts(adminAccess)).toBe(true);
+    });
+
+    it("returns false for accounting", () => {
+      expect(canManageFinancialAccounts(accountingAccess)).toBe(false);
+    });
+
+    it("returns false for general user", () => {
+      expect(canManageFinancialAccounts(generalAccess)).toBe(false);
+    });
+  });
+});

--- a/tests/lib/transfer-validation.test.ts
+++ b/tests/lib/transfer-validation.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { createTransferSchema } from "@/lib/validations";
+import { transferFormSchema } from "@/lib/schema";
+
+// ---------------------------------------------------------------------------
+// Server-side createTransferSchema
+// ---------------------------------------------------------------------------
+
+describe("createTransferSchema", () => {
+  const validInput = {
+    date: "2026-06-12",
+    amount: 10000,
+    fromAccountId: "550e8400-e29b-41d4-a716-446655440000",
+    toAccountId: "550e8400-e29b-41d4-a716-446655440001",
+    description: "銀行口座から金庫へ移動",
+  };
+
+  it("accepts valid input", () => {
+    const result = createTransferSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects zero amount", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      amount: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative amount", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      amount: -100,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects same source and destination", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      toAccountId: validInput.fromAccountId,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty description", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      description: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid UUID for fromAccountId", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      fromAccountId: "not-a-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts optional receiptUrl and remarks", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      receiptUrl: "path/to/receipt.webp",
+      remarks: "Some notes",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts null receiptUrl and remarks", () => {
+    const result = createTransferSchema.safeParse({
+      ...validInput,
+      receiptUrl: null,
+      remarks: null,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client-side transferFormSchema
+// ---------------------------------------------------------------------------
+
+describe("transferFormSchema", () => {
+  const validInput = {
+    date: new Date("2026-06-12"),
+    amount: 5000,
+    from_account_id: "550e8400-e29b-41d4-a716-446655440000",
+    to_account_id: "550e8400-e29b-41d4-a716-446655440001",
+    description: "金庫から銀行口座へ入金",
+  };
+
+  it("accepts valid input", () => {
+    const result = transferFormSchema.safeParse(validInput);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects same from and to accounts", () => {
+    const result = transferFormSchema.safeParse({
+      ...validInput,
+      to_account_id: validInput.from_account_id,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const toAccountError = result.error.errors.find(
+        (e) => e.path.includes("to_account_id"),
+      );
+      expect(toAccountError).toBeDefined();
+    }
+  });
+
+  it("rejects zero amount", () => {
+    const result = transferFormSchema.safeParse({
+      ...validInput,
+      amount: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty description", () => {
+    const result = transferFormSchema.safeParse({
+      ...validInput,
+      description: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
# 部全体会計・財布別記録 実装計画

## 概要

`docs/club-wide-ledger-spec.md` に基づき、部全体の収入・支出・資金移動を管理する機能を実装した。

## 変更ファイル一覧

### データベース (マイグレーション)

- `supabase/migrations/20260612120000_add_club_wide_ledger.sql`
  - `financial_accounts` テーブル作成 + 初期データ (金庫, 銀行口座)
  - `accounting_groups` に部全体 (type=club) を追加
  - `transactions` に `financial_account_id`, `transaction_kind`, `transfer_id` カラム追加
  - 既存データのバックフィル (financial_account_id=金庫, transaction_kind=income/expense)
  - NOT NULL 制約と CHECK 制約の追加
  - `v_ledger_transactions` ビューの更新
  - `get_budget_usage` 関数の更新 (transfer を除外)
  - `create_transfer` RPC 関数の作成
  - RLS ポリシー (financial_accounts, 部全体取引の制限)
  - ヘルパー関数 (`is_club_group`, `is_accounting_or_admin`)

### 型定義・スキーマ

- `lib/database.types.ts` — financial_accounts テーブル型、transactions の新カラム型、transaction_kind enum、create_transfer RPC 型
- `lib/schema.ts` — formSchema に `financial_account_id` 追加、`transferFormSchema` 新規作成
- `lib/validations.ts` — `createTransferSchema`, `fetchClubLedgerTransactionsSchema` 追加
- `lib/types.ts` — 変更なし (ActionResult は汎用)

### ビジネスロジック

- `lib/ledger.ts` — TransactionRow/LedgerTransaction に新フィールド追加、AmountLike 型拡張、`calculateClubLedgerSummary` 関数追加
- `lib/auth/permissions.ts` — `canViewClubLedger`, `canCreateClubTransaction`, `canManageFinancialAccounts`, `verifyClubTransactionPermission` 追加
- `lib/teams.ts` — club タイプのグループを full-access ユーザーに表示

### サーバーアクション

- `app/actions.ts` — `createTransaction` に financial_account_id/transaction_kind 追加、部全体グループの権限チェック追加、`updateTransaction` に financial_account_id/transaction_kind 追加
- `app/(authenticated)/ledger/actions.ts` — fetchLedgerTransactions に新カラム取得・部全体アクセス制御追加、`fetchFinancialAccounts` 新規、`createTransfer` 新規

### UI コンポーネント

- `components/ledger-view.tsx` — 財布フィルタ/種別フィルタ/クラブサマリー/拡張カラム対応
- `components/ledger/ledger-filter-bar.tsx` — 財布フィルタ・種別フィルタ Select 追加
- `components/ledger/ledger-desktop-table.tsx` — 財布・種別カラム表示 (showExtendedColumns)
- `components/ledger/ledger-mobile-cards.tsx` — 財布・種別情報の表示
- `components/ledger/ledger-summary.tsx` — 変更なし (既存サマリー)
- `components/ledger/club-ledger-summary.tsx` — 新規: 部全体サマリーカード
- `components/ledger/types.ts` — FinancialAccountInfo エクスポート、TRANSACTION_KIND_LABELS 追加
- `components/ledger/index.ts` — ClubLedgerSummary エクスポート追加
- `components/transaction-form.tsx` — 財布 Select フィールド追加
- `components/transfer-form.tsx` — 新規: 資金移動フォームダイアログ

### テスト

- `tests/lib/club-ledger.test.ts` — calculateClubLedgerSummary、集計ヘルパーの transfer 除外、権限ヘルパーのテスト
- `tests/lib/transfer-validation.test.ts` — createTransferSchema、transferFormSchema のバリデーションテスト

## 設計判断

### 1. transaction_kind の実装方法

PostgreSQL の CHECK 制約 (`income`, `expense`, `transfer`) を使用。enum 型は将来の値追加時にマイグレーションが重くなるため、text + CHECK を選択。TypeScript 側では database.types.ts に `transaction_kind` enum として定義。

### 2. 資金移動のアトミック性

`create_transfer` PL/pgSQL 関数で 2行を同一トランザクション内で INSERT。クライアント側のトランザクションヘルパーがないため、サーバーサイド RPC を選択。

### 3. RLS ポリシーの設計

- 部全体 (type=club) の SELECT は `is_accounting_or_admin()` で制限
- 部全体の INSERT も同様に制限
- 既存の班別取引ポリシーは変更なし (CASE 式で分岐)

### 4. 財布フィルタの表示条件

部全体会計グループ選択時のみ財布・種別フィルタを表示。班別出納帳では非表示 (従来の見え方を維持)。

### 5. 期首残高

仕様書の決定事項に従い、通常の繰越取引として入力する方式を採用。特別な UI は不要。
