### PR TITLE
Add specific error message for duplicate email and remove baseUrl from tsconfig

### DIFF
--- a/app/(authenticated)/members/manage/actions.ts
+++ b/app/(authenticated)/members/manage/actions.ts
@@ -76,6 +76,12 @@ export async function addMember(raw: {
   );
   if (createErr || !created.user) {
     console.error(createErr);
+    // Duplicate email = the derived email ({student_number}@...) is already
+    // registered. Surface a specific message so the operator can correct the
+    // student number instead of seeing a generic failure.
+    if (createErr?.code === "email_exists") {
+      return { error: "この学籍番号はすでに登録されています" } as const;
+    }
     return { error: "ユーザー作成に失敗しました" } as const;
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Enhance the member addition feature by providing a specific error message when a duplicate email is encountered. Remove the baseUrl option from tsconfig.json for cleaner configuration.